### PR TITLE
Enable non-root users other than the default jenkins user

### DIFF
--- a/_entrypoint.sh
+++ b/_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+UID=${1}
+GID=${2}
+shift
+shift
+
+S6_CMD_WAIT_FOR_SERVICES=1 exec /init setpriv "--reuid=$UID" "--regid=$GID" --init-groups -- "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec -- fixuid -q -- /_entrypoint "$(id -u)" "$(id -g)" "$@"


### PR DESCRIPTION
By using fixuid. However, most of the work was made in order to wrap the s6-overlay's init in a suid capable binary so it still runs as root.

We also drop support for gosu in favor of setpriv, which is now more adopted and even comes preinstalled in newer distributions.

This is a workaround until https://github.com/just-containers/s6-overlay/pull/303 does not get merged.

Refs: https://github.com/neurobin/shc/issues/119