### PR TITLE
Only pin docker-ce version

### DIFF
--- a/devcontainer/scripts/prepare_image.sh
+++ b/devcontainer/scripts/prepare_image.sh
@@ -57,12 +57,6 @@ ${APT_GET} update
 
 # renovate: datasource=github-releases depName=moby/moby
 DOCKER_VERSION="25.0.5"
-# renovate: datasource=github-releases depName=containerd/containerd
-CONTAINERD_VERSION="1.6.28"
-# renovate: datasource=github-releases depName=docker/buildx
-DOCKER_BUILDX_VERSION="0.13.1"
-# renovate: datasource=github-releases depName=docker/compose
-DOCKER_COMPOSE_VERSION="2.25.0"
 
 packages=(
     build-essential
@@ -99,9 +93,9 @@ packages=(
     # docker
     "docker-ce=5:${DOCKER_VERSION}-*"
     "docker-ce-cli=5:${DOCKER_VERSION}-*"
-    "containerd.io=${CONTAINERD_VERSION}-*"
-    "docker-buildx-plugin=${DOCKER_BUILDX_VERSION}-*"
-    "docker-compose-plugin=${DOCKER_COMPOSE_VERSION}-*"
+    containerd.io
+    docker-buildx-plugin
+    docker-compose-plugin
 )
 
 ${APT_GET_INSTALL} "${packages[@]}"


### PR DESCRIPTION
This way Renovate will not send unuseful PRs for docker-compose, containerd and docker-buildx.

This makes some sense since docker will only update their versions in the repositories when the version of docker-ce itself changes as well.

The drawback however is that, if a new version of docker is released but we don't update quickly,
other builds will contain the latest version of docker-compose, containerd and docker-buildx, but the docker-ce build will not.

Since there is no perfect option for now (looking for https://github.com/renovatebot/renovate/discussions/27716), I'll go with this one since it will minimize effort and noise.
