### PR TITLE
Add Volta back as a pkgx stub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ARG USER_ID="1000"
 # drawback still pays off as running this image as root is a corner case.
 ENV USER="${USER}"
 ENV HOME="/home/${USER}"
-ENV PATH="${HOME}/.local/bin:${PATH}"
+ENV PATH="${HOME}/.local/bin:${HOME}/.volta/bin:${PATH}"
 
 RUN --mount=type=bind,source=devcontainer/scripts/prepare_user.sh,target=/prepare_user.sh \
     /prepare_user.sh

--- a/devcontainer/scripts/prepare_image.sh
+++ b/devcontainer/scripts/prepare_image.sh
@@ -133,6 +133,9 @@ PKGX_VERSION="1.1.6"
 ${CURL} "https://github.com/pkgxdev/pkgx/releases/download/v${PKGX_VERSION}/pkgx-${PKGX_VERSION}+linux+${UNAME_ARCH//_/-}.tar.xz" |
     tar -C /usr/local/bin -xJf - pkgx
 
+# install volta stub (will be fully downloaded when it is used for the first time)
+pkgx install volta.sh
+
 # install s6-overlay
 # renovate: datasource=github-releases depName=just-containers/s6-overlay
 S6_OVERLAY_VERSION="3.1.6.2"


### PR DESCRIPTION
The `devcontainer:1` and `jenkins-agent-dind:1` had Volta installed by default, so this makes it easier to switch.

Also, Volta still has some meaningful advantages over pkgx. To name a few:

- Volta is a lot quicker to run node.js (https://github.com/pkgxdev/pkgx/issues/991)
- pkgx doesn't yet support reading node and npm versions from `volta` key in `package.json` (https://github.com/pkgxdev/pkgx/pull/980)
- Volta has `volta pin` and Renovate understands it (https://github.com/pkgxdev/dev/issues/21)
- pkgx doesn't yet support old versions of node and npm (https://github.com/pkgxdev/pantry/issues/5582)

However, Volta is now provided only as a pkgx stub (thanks to https://github.com/pkgxdev/pantry/pull/5586). Meaning it will only be downloaded when used for the first time, and therefore the size of the image is kept minimal. If you want to keep using pkgx to install node and npm, there's no problem in that. pkgs installed by pkgx will be preferred over Volta's.

Here's an example on how to profit from Volta:

```dockerfile
FROM ghcr.io/felipecrs/devcontainer:2

RUN --mount=type=bind,source=package.json,target=/tmp/package.json \
  volta install \
  "node@$(jq -er .volta.node /tmp/package.json)" \
  "npm@$(jq -er .volta.npm /tmp/package.json)"
```