### PR TITLE
Add python3 and pipx

### DIFF
--- a/devcontainer/scripts/prepare_image.sh
+++ b/devcontainer/scripts/prepare_image.sh
@@ -65,6 +65,8 @@ packages=(
     tree
     jq
     parallel
+    python3
+    pipx
     rsync
     sshpass
     zip

--- a/devcontainer/scripts/prepare_user.sh
+++ b/devcontainer/scripts/prepare_user.sh
@@ -43,7 +43,7 @@ VOLTA_VERSION="1.1.1"
 sudo -u "${USER}" pkgx install "volta.sh@${VOLTA_VERSION}"
 
 # cleanup
-sudo -u "${USER}" rm -rf "${HOME}/.pkgx" "${HOME}/.cache/pkgx"
+sudo -u "${USER}" rm -rf "${HOME}/.pkgx" "${HOME}/.cache/pkgx" "${HOME}/.local/share/pkgx"
 
 shopt -s nullglob dotglob
 rm -rf /tmp/* /var/cache/* /var/lib/apt/lists/*


### PR DESCRIPTION
The python3 package was present already before it was upgraded to Ubuntu
24.04, so this will fix this regression.

It is very useful to have some version of Python 3 available upfront for
running unknown scripts and workloads.

For example, a lot of Node.js dependencies depends on Python 3 to build
native modules.

Unfortunately, adding the python3 package back to the image increases
the image size by 40MB.

This also adds pipx to the images, so that Python-based tools can be
installed globally with no headaches. The pipx package itself does not
add any meaningful size to the image.
