### PR TITLE
Prefer volta binaries over pkgx ones if available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ARG USER_ID="1000"
 # drawback still pays off as running this image as root is a corner case.
 ENV USER="${USER}"
 ENV HOME="/home/${USER}"
-ENV PATH="${HOME}/.local/bin:${HOME}/.volta/bin:${PATH}"
+ENV PATH="${HOME}/.volta/bin:${HOME}/.local/bin:${PATH}"
 
 RUN --mount=type=bind,source=devcontainer/scripts/prepare_user.sh,target=/prepare_user.sh \
     /prepare_user.sh


### PR DESCRIPTION
1. No binaries will be available by default, so this will only be effective if users actually `volta install` things.
2. Volta is a more specialized solution, so when their binaries are present, they should be preferred.
