### PR TITLE
Bypass dind hack when running with Sysbox

### DIFF
--- a/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/run
+++ b/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/run
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 echo "[dind] starting service" >&2
+
+set -- s6-notifyoncheck -c /etc/s6-overlay/s6-rc.d/dind/check_readiness.sh
+
+if grep -qw sysboxfs /proc/self/mountinfo; then
+    exec "${@}" dockerd
+fi
+
 # the sleep helps workaround the "sed: couldn't flush stdout: Device or resource busy"
 # error on first startup attempt
-exec s6-notifyoncheck -c /etc/s6-overlay/s6-rc.d/dind/check_readiness.sh \
-    bash -c 'sleep 0.5s && exec dind dockerd'
+exec "${@}" bash -c 'sleep 0.5s && exec dind dockerd'


### PR DESCRIPTION
Sysbox makes the dind hack unnecessary. We can just execute dockerd directly.

I don't feel that undoing https://github.com/docker-library/docker/blob/485fefe743baed5a2dd9e5d22b685c14eda4c61e/Dockerfile-dind.template#L47-L52 is necessary.

Closes #61 