### PR TITLE
Revert "Use my pkgx fork while main repo is inactive (#185)"

### DIFF
--- a/devcontainer/scripts/prepare_image.sh
+++ b/devcontainer/scripts/prepare_image.sh
@@ -131,9 +131,9 @@ ${CURL} "https://github.com/kadwanev/retry/releases/download/${RETRY_VERSION}/re
     tar -C /usr/local/bin -xzf - retry
 
 # install pkgx
-# renovate: datasource=github-releases depName=felipecrs/pkgx versioning=loose
-PKGX_VERSION="1.2.0-felipecrs.2"
-${CURL} "https://github.com/felipecrs/pkgx/releases/download/v${PKGX_VERSION}/pkgx-${PKGX_VERSION}+linux+${UNAME_ARCH//_/-}.tar.xz" |
+# renovate: datasource=github-releases depName=pkgxdev/pkgx
+PKGX_VERSION="1.2.2"
+${CURL} "https://github.com/pkgxdev/pkgx/releases/download/v${PKGX_VERSION}/pkgx-${PKGX_VERSION}+linux+${UNAME_ARCH//_/-}.tar.xz" |
     tar -C /usr/local/bin -xJf - pkgx
 
 # install s6-overlay


### PR DESCRIPTION
This reverts commit 4cc39b4bdf42cb94311c147eec47cf16941648bd, thanks to
https://github.com/pkgxdev/libpkgx/pull/78.
