### PR TITLE
Add cgroup-scripts to devcontainer and jenkins-agent-dind

### DIFF
--- a/devcontainer/scripts/prepare_image.sh
+++ b/devcontainer/scripts/prepare_image.sh
@@ -154,6 +154,17 @@ ${CURL} "https://github.com/felipecrs/docker-on-docker-shim/raw/v${DOND_SHIM_VER
     -o /usr/local/bin/dond
 chmod +x /usr/local/bin/dond
 
+# install cgroup-scripts
+# renovate: datasource=github-releases depName=felipecrs/cgroup-scripts
+CGROUP_SCRIPTS_VERSION="0.1.0"
+mkdir -p /opt/cgroup-scripts
+${CURL} "https://github.com/felipecrs/cgroup-scripts/raw/v${CGROUP_SCRIPTS_VERSION}/get_cpus.sh" \
+    -o /opt/cgroup-scripts/get_cpus.sh
+chmod +x /opt/cgroup-scripts/get_cpus.sh
+${CURL} "https://github.com/felipecrs/cgroup-scripts/raw/v${CGROUP_SCRIPTS_VERSION}/get_memory.sh" \
+    -o /opt/cgroup-scripts/get_memory.sh
+chmod +x /opt/cgroup-scripts/get_memory.sh
+
 # setup oh my bash, useful when debugging the container
 ${CURL} https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh |
     bash -s -- --prefix=/opt/oh-my-bash --unattended


### PR DESCRIPTION
This should make it a lot easier to figure out the number of available CPUs and memory within pipelines.