### PR TITLE
Check if container is running in privileged mode before starting dind

### DIFF
--- a/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/finish
+++ b/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/finish
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# 111 is a signal from ./run
+if [[ "${1}" -eq 111 ]]; then
+    # 125 indicates a permanent failure to s6-overlay, which aborts the startup
+    exit 125
+fi

--- a/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/run
+++ b/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/run
@@ -8,6 +8,12 @@ if grep -qw sysboxfs /proc/self/mountinfo; then
     exec "${@}" dockerd
 fi
 
+if ! /opt/docker-scripts/is_privileged.sh; then
+    echo "[dind] the container must be running in privileged mode for dind to work" >&2
+    # an arbitrary exit code, used as a signal to ./finish to abort the startup
+    exit 111
+fi
+
 # the sleep helps workaround the "sed: couldn't flush stdout: Device or resource busy"
 # error on first startup attempt
 exec "${@}" bash -c 'sleep 0.5s && exec dind dockerd'

--- a/devcontainer/scripts/prepare_image.sh
+++ b/devcontainer/scripts/prepare_image.sh
@@ -154,16 +154,12 @@ ${CURL} "https://github.com/felipecrs/docker-on-docker-shim/raw/v${DOND_SHIM_VER
     -o /usr/local/bin/dond
 chmod +x /usr/local/bin/dond
 
-# install cgroup-scripts
-# renovate: datasource=github-releases depName=felipecrs/cgroup-scripts
-CGROUP_SCRIPTS_VERSION="0.2.0"
-mkdir -p /opt/cgroup-scripts
-${CURL} "https://github.com/felipecrs/cgroup-scripts/raw/v${CGROUP_SCRIPTS_VERSION}/get_cpus.sh" \
-    -o /opt/cgroup-scripts/get_cpus.sh
-chmod +x /opt/cgroup-scripts/get_cpus.sh
-${CURL} "https://github.com/felipecrs/cgroup-scripts/raw/v${CGROUP_SCRIPTS_VERSION}/get_memory.sh" \
-    -o /opt/cgroup-scripts/get_memory.sh
-chmod +x /opt/cgroup-scripts/get_memory.sh
+# install docker-scripts
+# renovate: datasource=github-releases depName=felipecrs/docker-scripts
+DOCKER_SCRIPTS_VERSION="0.2.0"
+mkdir -p /opt/docker-scripts
+${CURL} "https://github.com/felipecrs/docker-scripts/archive/v${DOCKER_SCRIPTS_VERSION}.tar.gz" |
+    tar -C /opt/docker-scripts --strip-components=2 -xzf - --wildcards "docker-scripts-*/scripts"
 
 # setup oh my bash, useful when debugging the container
 ${CURL} https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh |


### PR DESCRIPTION
This should make the container exit faster and with a better error message in case the user forgot to run it in privileged mode.

This PR also fixes the issue caused by #250.
