### PR TITLE
Fix jenkins-agent workdir ownership and permissions during entrypoint

### DIFF
--- a/jenkins-agent-dind/rootfs/etc/fix-attrs.d/jenkins-agent-workdir
+++ b/jenkins-agent-dind/rootfs/etc/fix-attrs.d/jenkins-agent-workdir
@@ -1,0 +1,1 @@
+/home/jenkins/agent false jenkins 0644 0755


### PR DESCRIPTION
Some clusters for some reason do not honor the permissions set by the Dockerfile.

This works around it by fixing the ownership and permissions of the jenkins-agent workdir during the entrypoint (as it used to be done by `jenkins-agent-dind:1`).

Note that this uses `fix-attrs.d` which is a deprecated feature of s6-overlay, but we can worry about it when it's actually removed.
