### PR TITLE
Fix "Fix docker not available when Jenkins calls it too early"

### DIFF
--- a/devcontainer/rootfs/after_initialization.sh
+++ b/devcontainer/rootfs/after_initialization.sh
@@ -2,6 +2,15 @@
 
 set -eu
 
-touch /tmp/container_initialized
+docker_binary_original_path="$(command -v docker.real)"
+docker_path="${docker_binary_original_path/".real"/}"
+docker_binary_final_path="${docker_path}"
+# in docker on docker mode, use docker-on-docker-shim by default
+if mountpoint --quiet "/var/run/docker.sock"; then
+    docker_binary_final_path="${docker_path}.orig"
+    dond_path="$(command -v dond)"
+    mv -f "${dond_path}" "${docker_path}"
+fi
+mv -f "${docker_binary_original_path}" "${docker_binary_final_path}"
 
 exec -- "$@"

--- a/devcontainer/rootfs/entrypoint.sh
+++ b/devcontainer/rootfs/entrypoint.sh
@@ -15,18 +15,16 @@ for file in /entrypoint.d/*; do
     source "${file}"
 done
 
-set -- /after_initialization.sh "$@"
-
 uid="$(id -u)"
 if [[ "${uid}" -eq 0 ]]; then
     # If running as root, simply execute s6-overlay
     export USER="root"
     export HOME="/root"
-    set -- /init "$@"
+    set -- /init /after_initialization.sh "$@"
 else
     # Otherwise, fix uid and gid, run s6-overlay as root and then drop
     # privileges back to the user
-    set -- fixdockergid /init_as_root s6-setuidgid "${USER}" "$@"
+    set -- fixdockergid /init_as_root /after_initialization.sh s6-setuidgid "${USER}" "$@"
 fi
 
 exec -- "$@"

--- a/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/check_readiness.sh
+++ b/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/check_readiness.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-export SKIP_CONTAINER_INITIALIZATION_CHECK="true"
-exec docker version &>/dev/null
+exec docker.real version &>/dev/null

--- a/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/condition.sh
+++ b/devcontainer/rootfs/etc/s6-overlay/s6-rc.d/dind/condition.sh
@@ -5,13 +5,6 @@ set -eu
 # if the docker socket is mounted, it means we are running in docker on docker
 # mode and therefore we should not start the dind service
 if mountpoint --quiet "/var/run/docker.sock"; then
-    # in docker on docker mode, use docker-on-docker-shim by default
-    # the real docker is docker.orig as dokcer is our shim that waits for the container initialization
-    docker_path=$(command -v docker.orig)
-    mv -f "${docker_path}" "${docker_path}2"
-    dond_path=$(command -v dond)
-    mv -f "${dond_path}" "${docker_path}"
-
     exit 1
 fi
 

--- a/devcontainer/rootfs/ssh-command/get.sh
+++ b/devcontainer/rootfs/ssh-command/get.sh
@@ -98,9 +98,9 @@ else
         if [[ -s "${sshd_port_file}" && -s "${node_fqdn_file}" ]]; then
             break
         elif [[ "${attempt}" -eq 5 ]]; then
-            log_task "Waiting more 25s for the '${sshd_port_file}' and '${node_fqdn_file}' files to be populated"
+            log_task "Waiting 25s more for the '${sshd_port_file}' and '${node_fqdn_file}' files to be populated"
         elif [[ "${attempt}" -eq 30 ]]; then
-            error "The '${sshd_port_file}' and '${node_fqdn_file}' files were not populated. Check the dynamic-hostports installation." >&2
+            error "The '${sshd_port_file}' and '${node_fqdn_file}' files were not populated after 30s. Check the dynamic-hostports installation." >&2
         fi
         sleep 1
     done
@@ -120,9 +120,9 @@ for attempt in {1..30}; do
     if [[ -f "${user_file}" ]]; then
         break
     elif [[ "${attempt}" -eq 5 ]]; then
-        log_task "Waiting more 25s for the '${user_file}' file to be created"
+        log_task "Waiting 25s more for the '${user_file}' file to be created"
     elif [[ "${attempt}" -eq 30 ]]; then
-        error "The '${user_file}' file was not created. Did the entrypoint script run?" >&2
+        error "The '${user_file}' file was not created after 30s. Did the entrypoint script run?" >&2
     fi
     sleep 1
 done

--- a/devcontainer/rootfs/usr/bin/docker
+++ b/devcontainer/rootfs/usr/bin/docker
@@ -34,18 +34,18 @@ function error() {
     exit 1
 }
 
-if [[ "${SKIP_CONTAINER_INITIALIZATION_CHECK:-"false"}" == "false" ]]; then
-    # Wait for 10s until the /tmp/container_initialized file is created
-    for attempt in {1..10}; do
-        if [[ -f /tmp/container_initialized ]]; then
-            break
-        elif [[ "${attempt}" -eq 5 ]]; then
-            log_task "Waiting more 5s for the /tmp/container_initialized file to be created"
-        elif [[ "${attempt}" -eq 10 ]]; then
-            error "The /tmp/container_initialized file was not created after 10s"
-        fi
-        sleep 1
-    done
-fi
+# Wait for 15s for the container to be initialized
+for attempt in {1..15}; do
+    # When the container is initialized, docker.real will be relocated
+    if ! command -v docker.real >/dev/null; then
+        break
+    elif [[ "${attempt}" -eq 5 ]]; then
+        log_task "Waiting 5s more for the container to be initialized"
+    elif [[ "${attempt}" -eq 15 ]]; then
+        error "The container was not initialized after 10s. Did the entrypoint script run?"
+    fi
+    sleep 1
+done
 
-exec -- docker.orig "$@"
+# At this point this script will have been replaced by the docker cli
+exec -- "$0" "$@"

--- a/devcontainer/scripts/prepare_image.sh
+++ b/devcontainer/scripts/prepare_image.sh
@@ -151,11 +151,11 @@ mkdir -p /run/sshd
 
 # prepare for the docker shim that waits for the container initialization
 docker_path=$(command -v docker)
-mv -f "${docker_path}" "${docker_path}.orig"
+mv -f "${docker_path}" "${docker_path}.real"
 
 # install docker-on-docker-shim
 # renovate: datasource=github-releases depName=felipecrs/docker-on-docker-shim
-DOND_SHIM_VERSION="0.8.0"
+DOND_SHIM_VERSION="0.7.1"
 ${CURL} "https://github.com/felipecrs/docker-on-docker-shim/raw/v${DOND_SHIM_VERSION}/dond" \
     -o /usr/local/bin/dond
 chmod +x /usr/local/bin/dond


### PR DESCRIPTION
The previous PR (#275) was merged because of a wrong branch protection setting.

It was in fact broken, and this PR fixes it.
