### PR TITLE
Reproduce kubernetes agents being picked up by a second build

### DIFF
--- a/jenkins-agent-dind/test-fixtures/jenkins.values.yaml.gotmpl
+++ b/jenkins-agent-dind/test-fixtures/jenkins.values.yaml.gotmpl
@@ -1,6 +1,7 @@
 persistence:
   enabled: true
 agent:
+  containerCap: 1
   image:
     repository: jenkins-agent-dind-test-registry:5000/jenkins-agent-dind
     tag: latest


### PR DESCRIPTION
This is a reproduction for [JENKINS-75731](https://issues.jenkins.io/browse/JENKINS-75731):

1. Clone this repository and switch to the `reproduce-jenkins-75731` branch.
2. Open it in VS Code, then reopen it in the devcontainer
3. `SKIP_BUILDS=true jenkins-agent-dind/test.sh`

Then, follow the demo below.

### Demo

1. Trigger test-agent-scripted once, wait for it to have an agent assigned and starts building
2. Trigger another test-agent-scripted build, wait for it to be waiting in queue
3. Cancel the first build triggered
4. Notice the second build gets assigned to the agent of the first build, and therefore fails immediately

https://github.com/user-attachments/assets/f78b0c49-5cb4-4aac-97b8-568cac757350


