### PR TITLE
Demonstrate workaround for Priority Sorter lack of regex support

### DIFF
--- a/jenkins-agent-dind/test-fixtures/Dockerfile
+++ b/jenkins-agent-dind/test-fixtures/Dockerfile
@@ -18,4 +18,5 @@ RUN jenkins-plugin-cli --plugins \
     pipeline-graph-view \
     saferestart \
     dark-theme \
-    locale
+    locale \
+    PrioritySorter:863.v4a_b_974a_5d042

--- a/jenkins-agent-dind/test-fixtures/jenkins.values.yaml.gotmpl
+++ b/jenkins-agent-dind/test-fixtures/jenkins.values.yaml.gotmpl
@@ -99,18 +99,14 @@ controller:
                 priority: 1
                 jobGroupStrategy:
                   viewBased:
-                    viewName: all
-                    useJobFilter: true
-                    jobPattern: "^test-agent-declarative$"
+                    viewName: declarative
               - description: lowest priority
                 id: 1
                 # https://issues.jenkins.io/browse/JENKINS-72401?focusedId=454953&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-454953
                 priority: 2
                 jobGroupStrategy:
                   viewBased:
-                    viewName: all
-                    useJobFilter: true
-                    jobPattern: "^test-agent-scripted$"
+                    viewName: scripted
       jobs: |
         jobs:
           - script: >
@@ -135,5 +131,25 @@ controller:
                       {{- readFile "jobs/test-agent-scripted/Jenkinsfile" | replace "\\" "\\\\" | replace "'''" "\\'''" | nindent 30 }}
                       '''.stripIndent())
                   }
+                }
+              }
+          - script: >
+              listView('declarative') {
+                jobs {
+                  recurse()
+                  regex('^test-agent/declarative$')
+                }
+                columns {
+                  name()
+                }
+              }
+          - script: >
+              listView('scripted') {
+                jobs {
+                  recurse()
+                  regex('^test-agent/scripted$')
+                }
+                columns {
+                  name()
                 }
               }

--- a/jenkins-agent-dind/test-fixtures/jenkins.values.yaml.gotmpl
+++ b/jenkins-agent-dind/test-fixtures/jenkins.values.yaml.gotmpl
@@ -1,6 +1,7 @@
 persistence:
   enabled: true
 agent:
+  containerCap: 1
   image:
     repository: jenkins-agent-dind-test-registry:5000/jenkins-agent-dind
     tag: latest
@@ -85,6 +86,31 @@ controller:
             ignoreAcceptLanguage: true
           themeManager:
             theme: darkSystem
+        unclassified:
+          prioritySorterConfiguration:
+            strategy:
+              absoluteStrategy:
+                defaultPriority: 2
+                numberOfPriorities: 2
+          priorityConfiguration:
+            jobGroups:
+              - description: highest priority
+                id: 0
+                priority: 1
+                jobGroupStrategy:
+                  viewBased:
+                    viewName: all
+                    useJobFilter: true
+                    jobPattern: "^test-agent-declarative$"
+              - description: lowest priority
+                id: 1
+                # https://issues.jenkins.io/browse/JENKINS-72401?focusedId=454953&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-454953
+                priority: 2
+                jobGroupStrategy:
+                  viewBased:
+                    viewName: all
+                    useJobFilter: true
+                    jobPattern: "^test-agent-scripted$"
       jobs: |
         jobs:
           - script: >


### PR DESCRIPTION
This PR is based on #422, but applies a workaround to support regex with folders in Priority Sorter.

Basically, this:

```yaml
viewName: all
useJobFilter: true
jobPattern: "^test-agent-declarative$"
```

Does not work for folders. Apparently, the search is not done recursively.

The workaround is to create views with recursive search enabled and with the wanted regex.

And then Priority Sorter can pick jobs from the view without further filters.

### Demo

https://github.com/user-attachments/assets/9a011de7-8f7e-4bc2-a1fe-398b8750a9df


