### PR TITLE
Replace `-v /var/run/docker.sock` with modern `--use-api-socket`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,11 @@
   },
   "overrideCommand": false,
   "runArgs": ["--use-api-socket", "--network=host"],
+  "mounts": [
+    // TODO: Test if this is still needed with --use-api-socket
+    // This allows sharing the build cache when running in GitHub Actions
+    "source=${localEnv:HOME}/.docker/buildx,target=/home/devcontainer/.docker/buildx,type=bind"
+  ],
   "postCreateCommand": [".devcontainer/post_create.sh"],
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,12 +5,7 @@
     "target": "devcontainer"
   },
   "overrideCommand": false,
-  "mounts": [
-    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-    // This allows sharing the build cache when running in GitHub Actions
-    "source=${localEnv:HOME}/.docker/buildx,target=/home/devcontainer/.docker/buildx,type=bind"
-  ],
-  "runArgs": ["--network=host"],
+  "runArgs": ["--use-api-socket", "--network=host"],
   "postCreateCommand": [".devcontainer/post_create.sh"],
   "customizations": {
     "vscode": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
             jenkins-agent-dind.cache-to=type=gha,scope=jenkins-agent-dind-${{ matrix.target.arch }},mode=max
           load: true
 
+      # TODO: Remove this before merging
+      - name: Print Docker version
+        run: docker version
+
       - name: Test
         uses: devcontainers/ci@v0.3
         with:

--- a/devcontainer/README.md
+++ b/devcontainer/README.md
@@ -29,9 +29,9 @@ Spin this image in your terminal, if you want to play with it:
 ```sh
 # --rm: removes the container and its volumes after exiting
 # -it: allows to interact with the container
-# --volume: shares the host's Docker socket with the container
+# --use-api-socket: shares the host's Docker socket with the container
 # --network=host: allows to access ports from other containers running on the host
-docker run --rm -it --volume=/var/run/docker.sock:/var/run/docker.sock --network=host \
+docker run --rm -it --use-api-socket --network=host \
   ghcr.io/felipecrs/devcontainer
 ```
 
@@ -66,13 +66,10 @@ To use it as a **Docker on Docker** devcontainer:
 // .devcontainer/devcontainer.json
 {
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
   },
   "overrideCommand": false,
-  "mounts": [
-    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
-  ],
-  "runArgs": ["--network=host"]
+  "runArgs": ["--use-api-socket", "--network=host"],
 }
 ```
 
@@ -82,10 +79,10 @@ Or, to use it as a **Docker in Docker** devcontainer:
 // .devcontainer/devcontainer.json
 {
   "build": {
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile",
   },
   "overrideCommand": false,
-  "privileged": true
+  "privileged": true,
 }
 ```
 
@@ -124,7 +121,7 @@ pipeline {
       dir '.devcontainer'
       // --group-add=docker: is needed when using docker exec to run commands,
       // which is what Jenkins does when running as a Jenkinsfile docker agent
-      args '--volume=/var/run/docker.sock:/var/run/docker.sock --network=host --group-add=docker'
+      args '--use-api-socket --network=host --group-add=docker'
     }
   }
   stages {

--- a/jenkins-agent-dind/README.md
+++ b/jenkins-agent-dind/README.md
@@ -37,9 +37,9 @@ docker run -it --rm --privileged ghcr.io/felipecrs/jenkins-agent-dind
 Alternatively, you can use the Docker on Docker mode:
 
 ```sh
-# --volume: shares the host's Docker socket with the container
+# --use-api-socket: shares the host's Docker socket with the container
 # --network=host: allows to access ports from other containers running on the host
-docker run -it --rm --volume=/var/run/docker.sock:/var/run/docker.sock --network=host \
+docker run -it --rm --use-api-socket --network=host \
   ghcr.io/felipecrs/jenkins-agent-dind
 ```
 
@@ -137,7 +137,7 @@ pipeline {
     docker {
       image 'ghcr.io/felipecrs/jenkins-agent-dind'
       alwaysPull true
-      args '--volume=/var/run/docker.sock:/var/run/docker.sock --group-add=docker --network=host'
+      args '--use-api-socket --group-add=docker --network=host'
     }
   }
   stages {
@@ -268,7 +268,7 @@ pipeline {
     docker {
       image 'ghcr.io/felipecrs/jenkins-agent-dind'
       alwaysPull true
-      args '--volume=/ssh-command:/ssh-command --volume=/var/run/docker.sock:/var/run/docker.sock --group-add=docker --network=host'
+      args '--volume=/ssh-command:/ssh-command --use-api-socket --group-add=docker --network=host'
     }
   }
   options {

--- a/jenkins-agent-dind/test-fixtures/jobs/test-agent-declarative/Jenkinsfile
+++ b/jenkins-agent-dind/test-fixtures/jobs/test-agent-declarative/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                         docker {
                             reuseNode true
                             image 'localhost:15432/jenkins-agent-dind:latest'
-                            args '--volume=/ssh-command:/ssh-command --volume=/var/run/docker.sock:/var/run/docker.sock --group-add=docker --network=host'
+                            args '--volume=/ssh-command:/ssh-command --use-api-socket --group-add=docker --network=host'
                         }
                     }
                     steps {

--- a/jenkins-agent-dind/test-fixtures/jobs/test-agent-scripted/Jenkinsfile
+++ b/jenkins-agent-dind/test-fixtures/jobs/test-agent-scripted/Jenkinsfile
@@ -25,7 +25,7 @@ timeout(time: 10, unit: 'MINUTES') {
 
             stage('Build Maven through Docker on Docker') {
                 docker.image('localhost:15432/jenkins-agent-dind:latest')
-                    .inside('--volume=/home/jenkins/.pkgx:/home/jenkins/.pkgx --volume=/home/jenkins/.m2:/home/jenkins/.m2 --use-api-socket --network=host') {
+                    .inside('--volume=/home/jenkins/.pkgx:/home/jenkins/.pkgx --volume=/home/jenkins/.m2:/home/jenkins/.m2 --use-api-socket --group-add=docker --network=host') {
                     sh 'pkgx +java@17 mvn@3 -o clean package'
                 }
             }

--- a/jenkins-agent-dind/test-fixtures/jobs/test-agent-scripted/Jenkinsfile
+++ b/jenkins-agent-dind/test-fixtures/jobs/test-agent-scripted/Jenkinsfile
@@ -11,7 +11,7 @@ timeout(time: 10, unit: 'MINUTES') {
 
         stage('Check Docker on Docker') {
             docker.image('localhost:15432/jenkins-agent-dind:latest')
-                .inside('--volume=/var/run/docker.sock:/var/run/docker.sock --group-add=docker --network=host') {
+                .inside('--use-api-socket --group-add=docker --network=host') {
                 // depending on the system, dond binary relocation can take some ms
                 sh 'sleep 1s'
                 sh 'docker version'
@@ -25,7 +25,7 @@ timeout(time: 10, unit: 'MINUTES') {
 
             stage('Build Maven through Docker on Docker') {
                 docker.image('localhost:15432/jenkins-agent-dind:latest')
-                    .inside('--volume=/home/jenkins/.pkgx:/home/jenkins/.pkgx --volume=/home/jenkins/.m2:/home/jenkins/.m2 --volume=/var/run/docker.sock:/var/run/docker.sock --group-add=docker --network=host') {
+                    .inside('--volume=/home/jenkins/.pkgx:/home/jenkins/.pkgx --volume=/home/jenkins/.m2:/home/jenkins/.m2 --use-api-socket --network=host') {
                     sh 'pkgx +java@17 mvn@3 -o clean package'
                 }
             }


### PR DESCRIPTION
Besides simpler to type, it also has some perks like automatically mounting the auth information (`config.json`) into the container.